### PR TITLE
Point to lwip GitHub mirror

### DIFF
--- a/master.xml
+++ b/master.xml
@@ -10,7 +10,6 @@
   <remote fetch="https://github.com/tass-belgium" name="picotcp" />
   <remote fetch="https://github.com/ruslo" name="polly" />
   <remote fetch="https://github.com/zeromq" name="zeromq" />
-  <remote fetch="https://git.savannah.gnu.org/git/" name="lwip"/>
 
   <default revision="master" remote="seL4"/>
 
@@ -41,5 +40,5 @@
   <project name="seL4_projects_libs.git" path="projects/seL4_projects_libs"/>
   <project name="polly" remote="polly" path="tools/polly" />
   <project name="libzmq" remote="zeromq" path="projects/libzmq" revision="refs/tags/v4.2.5" />
-  <project name="lwip.git" path="projects/lwip" remote="lwip" revision="refs/tags/STABLE-2_1_2_RELEASE"/>
+  <project name="lwip.git" path="projects/lwip" revision="refs/tags/STABLE-2_1_2_RELEASE"/>
 </manifest>


### PR DESCRIPTION
The upstream gnu.org git repo is too often unavailable for CI. Point to our own GitHub mirror in the seL4 org instead.

This change is only performed on master.xml -- default.xml will update automatically with the next CI run.